### PR TITLE
Lowered timeout on Python Task Queue API tests

### DIFF
--- a/test-suite/tests/taskqueue_tests.py
+++ b/test-suite/tests/taskqueue_tests.py
@@ -49,7 +49,7 @@ class PushQueueTest(HawkeyeTestCase):
     """
 
     start = datetime.datetime.now()
-    end = start + datetime.timedelta(0, 600)
+    end = start + datetime.timedelta(0, 30)
     while True:
       response = self.http_get('/taskqueue/counter?key={0}'.format(key))
       self.assertTrue(response.status == 200 or response.status == 404)
@@ -130,7 +130,7 @@ class PullQueueTest(HawkeyeTestCase):
     self.assertTrue(task_info['status'])
 
     start = datetime.datetime.now()
-    end = start + datetime.timedelta(0, 60)
+    end = start + datetime.timedelta(0, 30)
     while True:
       response = self.http_get('/taskqueue/pull')
       self.assertEquals(response.status, 200)


### PR DESCRIPTION
Lowered to 30 seconds, fixing issue #3.
