### PR TITLE
Remove CleanUpTaskEntities from Java baseline. We don't run it.

### DIFF
--- a/test-suite/hawkeye_baseline_java.csv
+++ b/test-suite/hawkeye_baseline_java.csv
@@ -56,7 +56,6 @@ tests.memcache_tests.MemcacheMultiDeleteTest, ok
 tests.memcache_tests.MemcacheMultiSetTest, ok
 tests.memcache_tests.MemcacheSetTest, ok
 tests.memcache_tests.SimpleJCacheTest, ok
-tests.taskqueue_tests.CleanUpTaskEntities, ok
 tests.taskqueue_tests.DeferredTaskTest, ok
 tests.taskqueue_tests.PushQueueTest, ok
 tests.taskqueue_tests.QueueStatisticsTest, ok


### PR DESCRIPTION
Old hawkeye run: https://ocd.appscale.com:8080/job/Hawkeye/6924/console

```
1 tests in baseline, but not run
    tests.taskqueue_tests.CleanUpTaskEntities = ok
```

New hawkeye run: https://ocd.appscale.com:8080/job/Hawkeye/6927/console
