### PR TITLE
Add a second of padding to match the Python app

### DIFF
--- a/java-app/src/com/appscale/hawkeye/taskqueue/LeaseModificationHandlerServlet.java
+++ b/java-app/src/com/appscale/hawkeye/taskqueue/LeaseModificationHandlerServlet.java
@@ -69,7 +69,7 @@ public class LeaseModificationHandlerServlet extends HttpServlet {
         }
 
         try {
-            Thread.sleep(duration*1000);
+            Thread.sleep(duration*1000 + 1000);
         } catch (InterruptedException e ){}
 
         try {


### PR DESCRIPTION
There are times in which clock skew between OCD instances allows the LWT to succeed even after waiting the duration of the original modification.
