### PR TITLE
Increment counter in transaction

### DIFF
--- a/python27-app/utils.py
+++ b/python27-app/utils.py
@@ -7,13 +7,18 @@ __author__ = 'hiranya'
 class TaskCounter(db.Model):
   count = db.IntegerProperty(indexed=False)
 
-def process(key):
-  counter = TaskCounter.get_by_key_name(key)
-  if counter is None:
-    counter = TaskCounter(key_name=key, count=1)
-  else:
+@db.transactional
+def increment_counter(key):
+  counter = db.get(key)
+  if counter is not None:
     counter.count += 1
+  else:
+    counter = TaskCounter(key_name=key.id_or_name(), count=1)
   counter.put()
+
+def process(key):
+  counter_key = db.Key.from_path('TaskCounter', key)
+  increment_counter(counter_key)
 
 def processEta(key, eta):
   actual = time.time()


### PR DESCRIPTION
Now that the Python hawkeye app allows multiple concurrent requests, a transaction is needed to ensure that tasks increment the counter in an atomic fashion.