### PR TITLE
Remove invalid queue entries

### DIFF
--- a/python27-app/queue.yaml
+++ b/python27-app/queue.yaml
@@ -2,15 +2,7 @@ queue:
 - name: hawkeyepython-PushQueue-0
   rate: 5/s
 
-# This queue should not be created.
-- name: largePushQueueName-largePushQueueName-largePushQueueName-largePushQueueName-largePushQueueName-largePushQueueName
-  rate: 1/s
-
 - name: hawkeyepython-PullQueue-0
-  mode: pull
-
-# This queue should not be created.
-- name: largePullQueueName-largePullQueueName-largePullQueueName-largePullQueueName-largePullQueueName-largePullQueueName
   mode: pull
 
 - name: rest-pull-queue


### PR DESCRIPTION
Since the AdminServer validates queue entries immediately, the invalid entries prevent the version from being deployed. There is now a unit test in the AdminServer package that contains more invalid queue configuration entries.