### PR TITLE
Include more content from HTTP responses

### DIFF
--- a/test-suite/hawkeye_utils.py
+++ b/test-suite/hawkeye_utils.py
@@ -6,7 +6,7 @@ from datetime import datetime
 import requests
 from requests.packages.urllib3.exceptions import InsecureRequestWarning
 
-LIMITED_BODY_LENGTH = 200
+LIMITED_BODY_LENGTH = 2000
 
 
 class ResponseInfo:


### PR DESCRIPTION
200 characters is usually not enough to see a typical stack trace.