### PR TITLE
Add LongTxRead to baseline

### DIFF
--- a/test-suite/hawkeye_baseline_python.csv
+++ b/test-suite/hawkeye_baseline_python.csv
@@ -47,6 +47,7 @@ tests.datastore_tests.KindAwareInsertWithParentTest.runTest,ok
 tests.datastore_tests.KindlessAncestorQueryTest.runTest,ok
 tests.datastore_tests.KindlessQueryTest.runTest,ok
 tests.datastore_tests.LimitedResultQueryTest.runTest,ok
+tests.datastore_tests.LongTxRead.runTest,ok
 tests.datastore_tests.MaxGroupsInTxn.runTest,ok
 tests.datastore_tests.MultipleEqualityFilters.runTest,ok
 tests.datastore_tests.OrderedKindAncestorQueryTest.runTest,ok


### PR DESCRIPTION
We've had this test for a while, but it's been missing from baseline.