### PR TITLE
Extract Java SDK with less verbosity

### DIFF
--- a/java-app/get_sdk.sh
+++ b/java-app/get_sdk.sh
@@ -8,7 +8,8 @@ else
         wget http://googleappengine.googlecode.com/files/${JAVA_SDK_ZIP}
 fi
 
-unzip ${JAVA_SDK_ZIP}
+echo "Extracting ${JAVA_SDK_ZIP}"
+unzip -q ${JAVA_SDK_ZIP}
 rm ${JAVA_SDK_ZIP}
 
 cd -


### PR DESCRIPTION
This removes over 1500 unnecessary lines from the Hawkeye job log output.