### PR TITLE
Add App Identity tests for Go runtime

### DIFF
--- a/go-app/app.go
+++ b/go-app/app.go
@@ -1,0 +1,15 @@
+package app
+
+import (
+	"app_identity"
+	"net/http"
+)
+
+func init() {
+	http.HandleFunc("/go/app_identity/project_id", app_identity.ProjectIDHandler)
+	http.HandleFunc("/go/app_identity/hostname", app_identity.HostnameHandler)
+	http.HandleFunc("/go/app_identity/access_token", app_identity.AccessTokenHandler)
+	http.HandleFunc("/go/app_identity/sign", app_identity.SignBlobHandler)
+	http.HandleFunc("/go/app_identity/certificates", app_identity.CertificateHandler)
+	http.HandleFunc("/go/app_identity/service_account_name", app_identity.ServiceAccountNameHandler)
+}

--- a/go-app/app.yaml
+++ b/go-app/app.yaml
@@ -1,0 +1,7 @@
+application: hawkeyego
+runtime: go
+api_version: go1
+
+handlers:
+- url: /.*
+  script: _go_app

--- a/go-app/app_identity/app_identity.go
+++ b/go-app/app_identity/app_identity.go
@@ -1,0 +1,117 @@
+package app_identity
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"appengine"
+)
+
+type AccessToken struct {
+	Token   string `json:"token"`
+	Expires int64  `json:"expires"`
+}
+
+type Certificate struct {
+	KeyName string `json:"key_name"`
+	PEM     string `json:"pem"`
+}
+
+type Signature struct {
+	KeyName   string `json:"key_name"`
+	Signature string `json:"signature"`
+}
+
+func ProjectIDHandler(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+	fmt.Fprint(w, appengine.AppID(c))
+}
+
+func HostnameHandler(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+	fmt.Fprint(w, appengine.DefaultVersionHostname(c))
+}
+
+func AccessTokenHandler(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+
+	token, expirationTime, err := appengine.AccessToken(
+		c, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	accessToken := AccessToken{token, expirationTime.Unix()}
+	output, err := json.Marshal(accessToken)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprint(w, string(output))
+}
+
+func SignBlobHandler(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+
+	encodedBlob := r.FormValue("blob")
+	blob, err := base64.URLEncoding.DecodeString(encodedBlob)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	keyName, signature, err := appengine.SignBytes(c, blob)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	encodedSignature := base64.StdEncoding.EncodeToString(signature)
+	signatureStruct := Signature{keyName, encodedSignature}
+	output, err := json.Marshal(signatureStruct)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprint(w, string(output))
+}
+
+func CertificateHandler(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+
+	certificates, err := appengine.PublicCertificates(c)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	certificateStructs := []Certificate{}
+	for _, certificate := range certificates {
+		certificateStruct := Certificate{
+			certificate.KeyName, string(certificate.Data)}
+		certificateStructs = append(certificateStructs, certificateStruct)
+	}
+
+	output, err := json.Marshal(certificateStructs)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Fprint(w, string(output))
+}
+
+func ServiceAccountNameHandler(w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+	serviceAccountName, err := appengine.ServiceAccount(c)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	fmt.Fprint(w, serviceAccountName)
+}


### PR DESCRIPTION
This adds a working Go application with the App Identity handlers. It does not add it to the automated tests yet.