### PR TITLE
Add App Identity tests for PHP runtime

### DIFF
--- a/php-app/app.php
+++ b/php-app/app.php
@@ -1,0 +1,21 @@
+<?php
+
+require 'app_identity.php';
+
+$request_uri = $_SERVER['PATH_INFO'];
+
+$routes = array(
+    '/php/app_identity/project_id' => 'projectIDHandler',
+    '/php/app_identity/hostname' => 'hostnameHandler',
+    '/php/app_identity/access_token' => 'accessTokenHandler',
+    '/php/app_identity/sign' => 'signBlobHandler',
+    '/php/app_identity/certificates' => 'certificateHandler',
+    '/php/app_identity/service_account_name' => 'serviceAccountNameHandler'
+);
+
+if (array_key_exists($request_uri, $routes)) {
+    call_user_func($routes[$request_uri]);
+} else {
+    header('HTTP/1.0 404 Not Found');
+    echo "Not Found";
+}

--- a/php-app/app.yaml
+++ b/php-app/app.yaml
@@ -1,0 +1,7 @@
+application: hawkeyephp
+runtime: php
+api_version: 1
+
+handlers:
+- url: /.*
+  script: app.php

--- a/php-app/app_identity.php
+++ b/php-app/app_identity.php
@@ -1,0 +1,42 @@
+<?php
+
+require_once 'google/appengine/api/app_identity/AppIdentityService.php';
+
+use google\appengine\api\app_identity\AppIdentityService;
+
+function projectIDHandler() {
+    echo AppIdentityService::getApplicationId();
+}
+
+function hostnameHandler() {
+    echo AppIdentityService::getDefaultVersionHostname();
+}
+
+function accessTokenHandler() {
+    $access_token = AppIdentityService::getAccessToken(
+        'https://www.googleapis.com/auth/cloud-platform');
+    $output = array('token' => $access_token['access_token'],
+                    'expires' => $access_token['expiration_time']);
+    echo json_encode($output);
+}
+
+function signBlobHandler() {
+    $encoded_blob = strtr($_GET['blob'], '-_', '+/'); // Convert urlsafe_base64 chars.
+    $blob = base64_decode($encoded_blob);
+    $signature = AppIdentityService::signForApp($blob);
+    $signature['signature'] = base64_encode($signature['signature']);
+    echo json_encode($signature);
+}
+
+function certificateHandler() {
+    $certs = array();
+    foreach(AppIdentityService::getPublicCertificates() as $certificate) {
+        $certs[] = array('key_name' => $certificate->getCertificateName(),
+                         'pem' => $certificate->getX509CertificateInPemFormat());
+    }
+    echo json_encode($certs);
+}
+
+function serviceAccountNameHandler() {
+    echo AppIdentityService::getServiceAccountName();
+}


### PR DESCRIPTION
This adds a working PHP application with the App Identity handlers. It does not add it to the automated tests yet.