### PR TITLE
Update pillow dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 cryptography
-pillow==3.3.1
+pillow>=3.3.2,<=5.2.0
 requests
 docopt


### PR DESCRIPTION
Version 3.3.1 was listed as having a security vulnerability.