### PR TITLE
Minor adjustments to get_sdk.sh script

### DIFF
--- a/java-app/get_sdk.sh
+++ b/java-app/get_sdk.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 JAVA_SDK_VERSION=1.8.4
 JAVA_SDK_ZIP=appengine-java-sdk-${JAVA_SDK_VERSION}.zip
 SDK_URL="http://s3.amazonaws.com/appscale-build/${JAVA_SDK_ZIP}"
@@ -7,17 +9,20 @@ if [ -e ${HOME}/${JAVA_SDK_ZIP} ]; then
         cp ${HOME}/${JAVA_SDK_ZIP} .
 else
         if ! wget ${SDK_URL}; then
-		echo "Failed to retrieve SDK from ${SDK_URL}, exiting script"
-		exit 1
-	fi
+                echo "Failed to retrieve SDK from ${SDK_URL}, exiting script"
+                cd -
+                exit 1
+        fi
 fi
 
 echo "Extracting ${JAVA_SDK_ZIP} to ${PWD}"
 
 if ! unzip -q ${JAVA_SDK_ZIP}; then
-	echo "Failed to unzip SDK correctly, please see errors above"
-	exit 1
+        echo "Failed to unzip SDK correctly, please see errors above"
+        rm -f ${JAVA_SDK_ZIP}
+        cd -
+        exit 1
 fi
-rm -f ${JAVA_SDK_ZIP}
 
+rm -f ${JAVA_SDK_ZIP}
 cd -

--- a/java-app/get_sdk.sh
+++ b/java-app/get_sdk.sh
@@ -1,15 +1,23 @@
 JAVA_SDK_VERSION=1.8.4
 JAVA_SDK_ZIP=appengine-java-sdk-${JAVA_SDK_VERSION}.zip
+SDK_URL="http://s3.amazonaws.com/appscale-build/${JAVA_SDK_ZIP}"
 
 cd ../../
 if [ -e ${HOME}/${JAVA_SDK_ZIP} ]; then
         cp ${HOME}/${JAVA_SDK_ZIP} .
 else
-        wget http://googleappengine.googlecode.com/files/${JAVA_SDK_ZIP}
+        if ! wget ${SDK_URL}; then
+		echo "Failed to retrieve SDK from ${SDK_URL}, exiting script"
+		exit 1
+	fi
 fi
 
-echo "Extracting ${JAVA_SDK_ZIP}"
-unzip -q ${JAVA_SDK_ZIP}
-rm ${JAVA_SDK_ZIP}
+echo "Extracting ${JAVA_SDK_ZIP} to ${PWD}"
+
+if ! unzip -q ${JAVA_SDK_ZIP}; then
+	echo "Failed to unzip SDK correctly, please see errors above"
+	exit 1
+fi
+rm -f ${JAVA_SDK_ZIP}
 
 cd -


### PR DESCRIPTION
### Changes
 - change url to an S3 bucket since google no longer stores that sdk
 - added error checking to wget command an unzip commands
 - added more info as to where the sdk is being extracted to.

### Demo

These are just some small changes to correctly error out when we can't download from a URL. Mainly stops execution when it can't download so we don't try to unzip a file that doesn't exist.

**Successful run:**
```
$ bash get_sdk.sh
--2018-12-04 14:51:54--  http://s3.amazonaws.com/appscale-build/appengine-java-sdk-1.8.4.zip
Resolving s3.amazonaws.com (s3.amazonaws.com)... 52.216.176.21
Connecting to s3.amazonaws.com (s3.amazonaws.com)|52.216.176.21|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 144774581 (138M) [application/zip]
Saving to: ‘appengine-java-sdk-1.8.4.zip’

appengine-java-sdk-1.8.4.zip  100%[=================================================>] 138.07M  28.2MB/s    in 5.2s    

2018-12-04 14:51:59 (26.6 MB/s) - ‘appengine-java-sdk-1.8.4.zip’ saved [144774581/144774581]

Extracting appengine-java-sdk-1.8.4.zip to /home/sgraham/dev/github
/home/sgraham/dev/github/sg-hawkeye/java-app
```
**Error downloading SDK**
```
$bash get_sdk.sh
--2018-12-04 15:01:19--  http://s3.amazonaws.com/appscale-build/appengine-java-sdk-1.8.4.zips
Resolving s3.amazonaws.com (s3.amazonaws.com)... 52.216.136.69
Connecting to s3.amazonaws.com (s3.amazonaws.com)|52.216.136.69|:80... connected.
HTTP request sent, awaiting response... 403 Forbidden
2018-12-04 15:01:19 ERROR 403: Forbidden.

Failed to retrieve SDK from http://s3.amazonaws.com/appscale-build/appengine-java-sdk-1.8.4.zips, exiting script
```
**Errors unziping file**
```
$ bash get_sdk.sh
Extracting foo.txt to /home/sgraham/dev/github
[foo.txt]
  End-of-central-directory signature not found.  Either this file is not
  a zipfile, or it constitutes one disk of a multi-part archive.  In the
  latter case the central directory and zipfile comment will be found on
  the last disk(s) of this archive.
unzip:  cannot find zipfile directory in one of foo.txt or
        foo.txt.zip, and cannot find foo.txt.ZIP, period.
Failed to unzip SDK correctly, please see errors above
```