### PR TITLE
Fix cprint fallback arguments

### DIFF
--- a/test-suite/hawkeye_test_runner.py
+++ b/test-suite/hawkeye_test_runner.py
@@ -10,12 +10,13 @@ try:
   from termcolor import cprint
 except ImportError:
   sys.stderr.write('termcolor module not found\n')
-  def cprint(msg, **kwargs):
+  def cprint(msg, *args, **kwargs):
     """
     Fallback definition of cprint in case the termcolor module is not available.
 
     Args:
       msg: a str to be printed stdout.
+      args: additional positional arguments for cprint that are ignored.
       kwargs: keyword arguments for cprint. It is ignored in dummy cprint.
     """
     print(msg)


### PR DESCRIPTION
This handles cases when the fallback function is called with additional positional arguments.