### PR TITLE
Check number of tasks from queue statistics

### DIFF
--- a/test-suite/hawkeye_baseline_java.csv
+++ b/test-suite/hawkeye_baseline_java.csv
@@ -73,7 +73,6 @@ tests.taskqueue_tests.LeaseModificationTest.runTest,ok
 tests.taskqueue_tests.PullQueueTest.runTest,ok
 tests.taskqueue_tests.PushQueueTest.runTest,ok
 tests.taskqueue_tests.QueueExistsTest.runTest,ok
-tests.taskqueue_tests.QueueStatisticsTest.runTest,ok
 tests.taskqueue_tests.TaskRetryTest.runTest,ok
 tests.taskqueue_tests.TransactionalTaskTest.runTest,ok
 tests.user_tests.LoginURLTest.runTest,ok

--- a/test-suite/tests/taskqueue_tests.py
+++ b/test-suite/tests/taskqueue_tests.py
@@ -164,6 +164,7 @@ class QueueStatisticsTest(DeprecatedHawkeyeTestCase):
     self.assertEquals(response.status, 200)
     task_info = json.loads(response.payload)
     self.assertEquals(task_info['queue'], 'default')
+    self.assertEquals(task_info['tasks'], 0)
 
 
 class PullQueueTest(DeprecatedHawkeyeTestCase):


### PR DESCRIPTION
This also removes queue stats from the Java baseline because they are not accurate.