### PR TITLE
OCD was changed to not use ssl, change the port so that tests pass

### DIFF
--- a/test-suite/tests/urlfetch_tests.py
+++ b/test-suite/tests/urlfetch_tests.py
@@ -8,7 +8,7 @@ from hawkeye_test_runner import HawkeyeTestSuite
 class CertificateValidation(DeprecatedHawkeyeTestCase):
   def run_hawkeye_test(self):
     good_cert = 'https://redmine.appscale.com/'
-    bad_cert = 'https://ocd.appscale.com:8080/'
+    bad_cert = 'https://ocd.appscale.net:8081/'
 
     vars = {'url': base64.urlsafe_b64encode(good_cert), 'validate': 'false'}
     response = self.http_get('/urlfetch?{}'.format(urllib.urlencode(vars)))


### PR DESCRIPTION
Stop gap solution to fix the cert validation tests. Long term we need to properly test an ssl endpoint that isn't specific to appscale. 