### PR TITLE
remove bad cert tests since the url isn't accessible publicly anymore

### DIFF
--- a/test-suite/tests/urlfetch_tests.py
+++ b/test-suite/tests/urlfetch_tests.py
@@ -18,13 +18,15 @@ class CertificateValidation(DeprecatedHawkeyeTestCase):
     response = self.http_get('/urlfetch?{}'.format(urllib.urlencode(vars)))
     self.assertEqual(response.status, 200)
 
-    vars = {'url': base64.urlsafe_b64encode(bad_cert), 'validate': 'false'}
-    response = self.http_get('/urlfetch?{}'.format(urllib.urlencode(vars)))
-    self.assertEqual(response.status, 200)
+# Remove bad cert tests since we don't expose them to the outside world anymore
 
-    vars = {'url': base64.urlsafe_b64encode(bad_cert), 'validate': 'true'}
-    response = self.http_get('/urlfetch?{}'.format(urllib.urlencode(vars)))
-    self.assertEqual(response.status, 500)
+#    vars = {'url': base64.urlsafe_b64encode(bad_cert), 'validate': 'false'}
+#    response = self.http_get('/urlfetch?{}'.format(urllib.urlencode(vars)))
+#    self.assertEqual(response.status, 200)
+
+#    vars = {'url': base64.urlsafe_b64encode(bad_cert), 'validate': 'true'}
+#    response = self.http_get('/urlfetch?{}'.format(urllib.urlencode(vars)))
+#    self.assertEqual(response.status, 500)
 
 
 def suite(lang, app):


### PR DESCRIPTION
This should be a "temporary" fix until we ship 3.7. I'll open up an issue so that we keep track of the issue. 