### PR TITLE
Python test application updated to require admin login for some handlers

### DIFF
--- a/python27-app/module-main/app.yaml
+++ b/python27-app/module-main/app.yaml
@@ -87,6 +87,10 @@ handlers:
 - url: /_ah/xmpp/message/chat/?
   script: main.app
 
+- url: /python/blobstore/upload
+  script: main.app
+  login: admin
+
 - url: /.*
   script: main.app
 

--- a/python27-app/module-warmup/app.yaml
+++ b/python27-app/module-warmup/app.yaml
@@ -5,6 +5,10 @@ api_version: 1
 threadsafe: true
 
 handlers:
+- url: /_ah/warmup
+  script: warmup.app
+  login: admin
+
 - url: /.*
   script: warmup.app
 


### PR DESCRIPTION
Handler changes to ensure that `login: admin` is supported for warmup and blobstore uploads.