### PR TITLE
Remove metadata queries from baseline

### DIFF
--- a/test-suite/hawkeye_baseline_python.csv
+++ b/test-suite/hawkeye_baseline_python.csv
@@ -60,7 +60,6 @@ tests.datastore_tests.LongTxRead.runTest,ok
 tests.datastore_tests.MaxGroupsInTxn.runTest,ok
 tests.datastore_tests.MergeJoinWithAncestor.test_merge_join_with_ancestor,ok
 tests.datastore_tests.MergeJoinWithKey.test_merge_join_with_key,ok
-tests.datastore_tests.MetadataQueries.test_kind_list,ok
 tests.datastore_tests.MultipleEqualityFilters.runTest,ok
 tests.datastore_tests.NonAsciiEntityKeys.runTest,ok
 tests.datastore_tests.OrderedKindAncestorQueryTest.runTest,ok


### PR DESCRIPTION
This will be re-added when the FDB backend is the default.