### PR TITLE
Remove channel tests from baseline

### DIFF
--- a/test-suite/hawkeye_baseline_java.csv
+++ b/test-suite/hawkeye_baseline_java.csv
@@ -9,7 +9,6 @@ tests.blobstore_tests.QueryBlobByKeyTest.runTest,ok
 tests.blobstore_tests.QueryBlobByPropertyTest.runTest,ok
 tests.blobstore_tests.QueryBlobDataTest.runTest,ok
 tests.blobstore_tests.UploadBlobTest.test_blobstore_upload_handler,ok
-tests.channel_tests.TestChannelAPI.test_js_receive,ok
 tests.cron_tests.CronTest.runTest,ok
 tests.datastore_tests.AncestorQueryTest.runTest,ok
 tests.datastore_tests.ComplexQueryCursorTest.runTest,ok

--- a/test-suite/hawkeye_baseline_python.csv
+++ b/test-suite/hawkeye_baseline_python.csv
@@ -35,7 +35,6 @@ tests.blobstore_tests.QueryBlobByKeyTest.runTest,ok
 tests.blobstore_tests.QueryBlobByPropertyTest.runTest,ok
 tests.blobstore_tests.QueryBlobDataTest.runTest,ok
 tests.blobstore_tests.UploadBlobTest.test_blobstore_upload_handler,ok
-tests.channel_tests.TestChannelAPI.test_js_receive,ok
 tests.cron_tests.CronTest.runTest,ok
 tests.cron_tests.CronTargetTest.test_cron_target,ok
 tests.datastore_tests.AncestorQueryTest.runTest,ok


### PR DESCRIPTION
They do not pass consistently on multinode deployment configurations. Taking them out of the baseline will reduce false negatives until we fix the problem.