### PR TITLE
Add test for empty namespaces in metadata queries

### DIFF
--- a/python27-app/module-main/datastore.py
+++ b/python27-app/module-main/datastore.py
@@ -1896,9 +1896,10 @@ class ManageEntity(webapp2.RequestHandler):
     json.dump(entity, self.response)
 
   def delete(self):
+    namespace = self.request.get('namespace', default_value=None)
     encoded_path = self.request.get('pathBase64').encode('utf-8')
     path = json.loads(base64.urlsafe_b64decode(encoded_path))
-    key = datastore.Key.from_path(*path)
+    key = datastore.Key.from_path(*path, namespace=namespace)
     datastore.Delete(key)
 
 

--- a/test-suite/tests/datastore_tests.py
+++ b/test-suite/tests/datastore_tests.py
@@ -1020,6 +1020,20 @@ class MetadataQueries(HawkeyeTestCase):
     namespaces = [entity['path'][-1] for entity in results]
     self.assertIn('ns2', namespaces)
 
+    # Add and delete separate namespace to see if it shows up in a metadata
+    # query.
+    namespace = 'ns3'
+    path = ('MetadataQueryDeleted', 'foo')
+    self.app.post('/{lang}/datastore/manage_entity',
+                  json={'namespace': namespace, 'kind': path[0], 'name': path[1]})
+    encoded_path = base64.urlsafe_b64encode(json.dumps(path))
+    self.app.delete('/{{lang}}/datastore/manage_entity'
+                    '?pathBase64={}&namespace={}'.format(encoded_path, namespace))
+    results = self.app.get('/{lang}/datastore/kind_query'
+                           '?kind=__namespace__').json()
+    namespaces = [entity['path'][-1] for entity in results]
+    self.assertNotIn(namespace, namespaces)
+
   def test_kind_list(self):
     results = self.app.get('/{lang}/datastore/kind_query?kind=__kind__').json()
     kinds = [entity['path'][-1] for entity in results]


### PR DESCRIPTION
This ensures that a recently-emptied namespace does not show up when querying a list of the project's namespaces.

Goes with https://github.com/AppScale/appscale/pull/3186.