### PR TITLE
Add test for auto ID generation in a transaction

### DIFF
--- a/python27-app/module-main/datastore.py
+++ b/python27-app/module-main/datastore.py
@@ -2,15 +2,17 @@ import base64
 import datetime
 import json
 import logging
+import os
 import random
 import string
 import time
 import unittest
 import uuid
 
+from google.appengine.api import app_identity
 from google.appengine.api import datastore
 from google.appengine.api import datastore_errors
-from google.appengine.datastore import datastore_query
+from google.appengine.datastore import datastore_pb, datastore_query
 from google.appengine.ext import db
 from google.appengine.ext import ndb
 from google.appengine.ext import webapp
@@ -35,6 +37,16 @@ def remove_db_entities(query):
     time.sleep(SDK_CONSISTENCY_WAIT)
     if entities_fetched < batch_size:
       break
+
+
+def prefixed_id():
+  project_id = app_identity.get_application_id()
+  if os.environ['SERVER_SOFTWARE'].startswith('Development'):
+    return 'dev~' + project_id
+  elif os.environ['SERVER_SOFTWARE'].startswith('Google App Engine'):
+    return 'm~' + project_id
+  else:
+    return project_id
 
 
 class Project(db.Model):
@@ -2113,6 +2125,52 @@ class QueryInTransaction(webapp2.RequestHandler):
     datastore.Put(entity)
 
 
+class RPC(webapp2.RequestHandler):
+  def post(self):
+    request_info = json.loads(self.request.body)
+
+    connection = datastore._GetConnection()
+    config = datastore._GetConfigFromKwargs({})
+
+    transaction = None
+    if request_info.get('wrapInTx'):
+      request = datastore_pb.BeginTransactionRequest()
+      request.set_app(prefixed_id())
+      request.set_allow_multiple_eg(True)
+      transaction = datastore_pb.Transaction()
+      connection.make_rpc_call(config, 'BeginTransaction', request,
+                               transaction).get_result()
+
+    if request_info['method'] == 'Put':
+      request = datastore_pb.PutRequest()
+      response = datastore_pb.PutResponse()
+
+      # TODO: Make this more generic so the client can create their own
+      #  requests.
+      for _ in range(2):
+        entity = request.add_entity()
+        entity.mutable_entity_group()
+        key = entity.mutable_key()
+        key.set_app(prefixed_id())
+        path = key.mutable_path()
+        element = path.add_element()
+        element.set_type('AutoIDsInTx')
+
+      if request_info.get('wrapInTx'):
+        request.mutable_transaction().CopyFrom(transaction)
+
+      connection.make_rpc_call(config, 'Put', request, response).get_result()
+    else:
+      raise Exception('Unexpected RPC method')
+
+    if request_info.get('wrapInTx'):
+      response = datastore_pb.CommitResponse()
+      connection.make_rpc_call(config, 'Commit', transaction, response).\
+        get_result()
+
+    self.response.write(response.Encode())
+
+
 urls = [
   ('/python/datastore/project', ProjectHandler),
   ('/python/datastore/module', ModuleHandler),
@@ -2150,5 +2208,6 @@ urls = [
   ('/python/datastore/merge_join_with_key', MergeJoinWithKey),
   ('/python/datastore/batch_query', BatchQuery),
   ('/python/datastore/more_results', CheckMoreResults),
-  ('/python/datastore/query_in_transaction', QueryInTransaction)
+  ('/python/datastore/query_in_transaction', QueryInTransaction),
+  ('/python/datastore/rpc', RPC)
 ]

--- a/test-suite/hawkeye_baseline_python.csv
+++ b/test-suite/hawkeye_baseline_python.csv
@@ -38,6 +38,7 @@ tests.blobstore_tests.UploadBlobTest.test_blobstore_upload_handler,ok
 tests.cron_tests.CronTest.runTest,ok
 tests.cron_tests.CronTargetTest.test_cron_target,ok
 tests.datastore_tests.AncestorQueryTest.runTest,ok
+tests.datastore_tests.AutoIDsInTransaction.test_entities_were_written,ok
 tests.datastore_tests.TestMoreResults.test_more_results,ok
 tests.datastore_tests.ComplexQueryCursorTest.runTest,ok
 tests.datastore_tests.CompositeMultiple.runTest,ok

--- a/test-suite/tests/datastore_tests.py
+++ b/test-suite/tests/datastore_tests.py
@@ -23,6 +23,16 @@ ALL_PROJECTS = {}
 SYNAPSE_MODULES = {}
 
 
+def clear_kind(requests, kind):
+  entities = requests.get(
+    '/{{lang}}/datastore/kind_query?kind={}'.format(kind)).json()
+  paths = [entity['path'] for entity in entities]
+  for path in paths:
+    encoded_path = base64.urlsafe_b64encode(json.dumps(path))
+    requests.delete('/{{lang}}/datastore/manage_entity'
+                    '?pathBase64={}'.format(encoded_path))
+
+
 class DataStoreCleanupTest(DeprecatedHawkeyeTestCase):
   def run_hawkeye_test(self):
     response = self.http_delete('/datastore/module')
@@ -1043,6 +1053,21 @@ class MetadataQueries(HawkeyeTestCase):
     self.assertNotIn(path[0], kinds)
 
 
+class AutoIDsInTransaction(HawkeyeTestCase):
+  KIND = 'AutoIDsInTx'
+
+  def test_entities_were_written(self):
+    response = self.app.post('/{lang}/datastore/rpc',
+                             json={'wrapInTx': True, 'method': 'Put'})
+    self.assertEqual(response.status_code, 200)
+    entities = self.app.get(
+      '/{{lang}}/datastore/kind_query?kind={}'.format(self.KIND)).json()
+    self.assertEqual(len(entities), 2)
+
+  def tearDown(self):
+    clear_kind(self.app, self.KIND)
+
+
 def suite(lang, app):
   suite = HawkeyeTestSuite('Datastore Test Suite', 'datastore')
   suite.addTests(DataStoreCleanupTest.all_cases(app))
@@ -1092,6 +1117,7 @@ def suite(lang, app):
     suite.addTests(TestMoreResults.all_cases(app))
     suite.addTests(QueryInTransaction.all_cases(app))
     suite.addTests(MetadataQueries.all_cases(app))
+    suite.addTests(AutoIDsInTransaction.all_cases(app))
   elif lang == 'java':
     suite.addTests(JDOIntegrationTest.all_cases(app))
     suite.addTests(JPAIntegrationTest.all_cases(app))


### PR DESCRIPTION
This uses a manual protobuf request to apply multiple puts (with partial keys) in a transaction.